### PR TITLE
#10: Replaced manual lifecycle management with traditional weak reference

### DIFF
--- a/library/src/main/java/com/programmerr47/phroom/MainThreadExecutor.kt
+++ b/library/src/main/java/com/programmerr47/phroom/MainThreadExecutor.kt
@@ -1,0 +1,13 @@
+package com.programmerr47.phroom
+
+import android.os.Handler
+import android.os.Looper
+import java.util.concurrent.Executor
+
+internal class MainThreadExecutor : Executor {
+    private val uiHandler = Handler(Looper.getMainLooper())
+
+    override fun execute(command: Runnable) {
+        uiHandler.post(command)
+    }
+}


### PR DESCRIPTION
I've tried to manage lifecycle of the view manually, but apparently there are some not obvious behavior in lists, when onAttach/onDetach related methods will be called, even if view will be slightly out of window, but onBindViewHolder will not be called, after view will accualy come to the screen (after onAttach), because this view was not recycled and thus data was not invalid.

So that was a bug.

We still should make manual lifecycle management to detach redundant views (when you leave the screen), but not finish the jobs (just deprioritize them) to save results in caches